### PR TITLE
if deleting the temp directory didn't work (because of race condition), retry up to five times

### DIFF
--- a/.changeset/itchy-students-accept.md
+++ b/.changeset/itchy-students-accept.md
@@ -1,0 +1,5 @@
+---
+"using-temporary-files": patch
+---
+
+retry deleting the temp directory if it failed due to a race condition

--- a/src/using-temporary-files.js
+++ b/src/using-temporary-files.js
@@ -72,13 +72,14 @@ export async function usingTemporaryFiles(...callbacks) {
 		}
 	} finally {
 		if (!DEBUG) {
-			let retries = 3;
+			let retries = 5;
 
 			while (retries > 0) {
 				try {
 					await fs.rm(temporaryDirectory, { recursive: true });
 					break;
 				} catch {
+					await new Promise(resolve => setTimeout(resolve, 200));
 					retries -= 1;
 				}
 			}

--- a/src/using-temporary-files.js
+++ b/src/using-temporary-files.js
@@ -56,7 +56,7 @@ export async function usingTemporaryFiles(...callbacks) {
 
 	const temporaryDirectory = `${await fs.mkdtemp(
 		nodePath.join(baseDirectory, "utf-")
-	)}/`;
+	)}`;
 
 	try {
 		for (const callback of callbacks) {
@@ -72,7 +72,16 @@ export async function usingTemporaryFiles(...callbacks) {
 		}
 	} finally {
 		if (!DEBUG) {
-			await fs.rm(temporaryDirectory, { recursive: true });
+			let retries = 3;
+
+			while (retries > 0) {
+				try {
+					await fs.rm(temporaryDirectory, { recursive: true });
+					break;
+				} catch {
+					retries -= 1;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
I think what's happening is a file gets written to the directory after the call to rm(). 